### PR TITLE
🔧 Repoint hikari example dependencies from retired dev to master.

### DIFF
--- a/examples/website/Cargo.toml
+++ b/examples/website/Cargo.toml
@@ -22,9 +22,9 @@ tairitsu-web = { path = "../../packages/web", features = [
 ], default-features = false }
 
 # Hikari design system
-hikari-palette = { git = "https://github.com/celestia-island/hikari.git", branch = "dev" }
-hikari-components = { git = "https://github.com/celestia-island/hikari.git", branch = "dev" }
-hikari-icons = { git = "https://github.com/celestia-island/hikari.git", branch = "dev", features = ["tairitsu"] }
+hikari-palette = { git = "https://github.com/celestia-island/hikari.git", branch = "master" }
+hikari-components = { git = "https://github.com/celestia-island/hikari.git", branch = "master" }
+hikari-icons = { git = "https://github.com/celestia-island/hikari.git", branch = "master", features = ["tairitsu"] }
 
 # Markdown rendering
 pulldown-cmark = "^0.12"


### PR DESCRIPTION
The `dev` branch of `hikari` was deleted in the org-wide dev-branch retirement. The example website workspace still pinned three `hikari-*` git dependencies to it, which breaks `cargo fetch`.

- `hikari-palette`, `hikari-components`, `hikari-icons`: `branch = "dev"` → `branch = "master"`

No other changes.