### PR TITLE
🐛 Use workspace version for tairitsu-browser.

### DIFF
--- a/packages/browser/Cargo.toml
+++ b/packages/browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tairitsu-browser"
-version = "0.5.13"
+version.workspace = true
 edition = "2024"
 rust-version = "1.85"
 authors = ["langyo <langyo.china@gmail.com>"]


### PR DESCRIPTION
tairitsu-browser had a hardcoded `version = "0.5.13"` instead of `version.workspace = true`, causing the publish workflow to pin the wrong crate version and fail.