### PR TITLE
🔧 Bump publish timeout; fix tairitsu-browser license-file.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,7 +66,7 @@ jobs:
   publish-crates:
     name: Publish to crates.io
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     needs: verify
     steps:
       - uses: actions/checkout@v4

--- a/packages/browser/Cargo.toml
+++ b/packages/browser/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 rust-version = "1.85"
 authors = ["langyo <langyo.china@gmail.com>"]
 license = "MIT"
-license-file = "LICENSE"
+license-file.workspace = true
 description = "Lightweight headless browser automation — CDP engine + HTTP debug API"
 repository = "https://github.com/celestia-island/tairitsu"
 


### PR DESCRIPTION
Two fixes for the publish workflow:

1. **Bump timeout** from 15→45 min (12 publishable crates × up to 5 min crates.io indexing)
2. **Fix tairitsu-browser** hardcoded `license-file = "LICENSE"` → `license-file.workspace = true`, matching all other sub-packages

Together with #29 (which fixed `version.workspace` for browser), these unblock the v0.5.18 publish.