### PR TITLE
✅ Add commit message lint CI workflow.

### DIFF
--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -1,0 +1,11 @@
+name: Commit Message Lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  lint-commits:
+    uses: celestia-island/celestia-devtools/.github/workflows/commit-msg-lint.yml@master


### PR DESCRIPTION
Installs `celestia-island/celestia-devtools` reusable commit-msg lint workflow. Validates PR title (squash merge subject) and all commits in the PR against org gitmoji convention.