### PR TITLE
♻️ Switch shirabe dependency from local path to git reference.

### DIFF
--- a/packages/e2e/Cargo.toml
+++ b/packages/e2e/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [dependencies]
 
-shirabe = { path = "../../../shirabe" }
+shirabe = { git = "https://github.com/celestia-island/shirabe.git", branch = "master" }
 
 anyhow = { workspace = true }
 async-trait = { workspace = true }


### PR DESCRIPTION
Replace local path dependency on shirabe with git reference per AGENTS.md §7. All cross-repo deps must use git references, never local path deps.