### PR TITLE
🔧 Drop synchronize from message checks and pin checkout to v7.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,7 +16,7 @@ jobs:
     name: Cargo Audit
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Remove e2e/website from workspace and local patches
         run: |
@@ -36,7 +36,7 @@ jobs:
     name: Cargo Deny
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Remove e2e/website from workspace and local patches
         run: |
@@ -56,7 +56,7 @@ jobs:
     name: NPM Audit
     runs-on: [self-hosted, linux, x64, local]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -23,7 +23,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Remove e2e/website from workspace and local patches
         run: |

--- a/.github/workflows/commit-msg-lint.yml
+++ b/.github/workflows/commit-msg-lint.yml
@@ -2,7 +2,7 @@ name: Commit Message Lint
 
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, edited, reopened, ready_for_review]
   merge_group:
     types: [checks_requested]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo install --git https://github.com/celestia-island/lagrange --branch dev lagrange-library --locked

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -9,7 +9,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened, ready_for_review]
 
 jobs:
   validate:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Verify versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Extract tag version
         id: tag
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -69,7 +69,7 @@ jobs:
     timeout-minutes: 45
     needs: verify
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Ensure tag is on master
         run: |
@@ -120,7 +120,7 @@ jobs:
     needs: verify
     if: false  # Disabled until @celestia-island/tairitsu-web-glue is registered on npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '22'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           - nightly
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Remove e2e/website from workspace and local patches
         run: |

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, linux, x64, local]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/wit-sync.yml
+++ b/.github/workflows/wit-sync.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v7


### PR DESCRIPTION
CI slim wave (AGENTS.md 7.4, PLAN.md claim 2026-08-31): message-check workflows now trigger only on opened/edited/reopened/ready_for_review instead of every push (synchronize), and actions/checkout is pinned to v7 org-wide — the self-hosted runners' action cache keeps only the latest downloaded version per action repo, so mixing v4/v5/v7 forces a 30s-2.5min re-download per job through the proxy. All changed YAML validated locally (yaml.safe_load_all).